### PR TITLE
WIP: Start of a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM gliderlabs/alpine:3.2
+WORKDIR /usr/src/app
+RUN apk -U add ruby ruby-bundler ruby-io-console nodejs tzdata
+COPY bundler_config /root/.bundle/config
+COPY Gemfile /usr/src/app/
+COPY Gemfile.lock /usr/src/app/
+RUN apk add -t build \
+    ruby-dev \
+    build-base \
+    libxml2-dev \
+    libxslt-dev \
+    libffi-dev \
+  && bundle install \
+  && apk del --purge build \
+  && rm -rf /var/cache/apk
+COPY . /usr/src/app

--- a/bundler_config
+++ b/bundler_config
@@ -1,0 +1,2 @@
+---
+BUNDLE_BUILD__NOKOGIRI: --use-system-libraries


### PR DESCRIPTION
Not the best. But a start. This is what I was using to run Middleman locally to view my changes:

```
d build -t gliderlabs .
dri -p 4567:4567 -p 35729:35729 -v $(pwd):/usr/src/app gliderlabs middleman server -b 0.0.0.0
```

The LiveReload thingy doesn't work (probably because inotify doesn't work over VirtualBox sharing). There is also no way to deploy yet (how to get SSH socket piped to container... hmmm...).

Nokogiri patches don't work on musl. Needs to be build against system libs, thus the custom `bundler_config` to pass in build flags.

The also relies on #7 (since Middleman can't actually install at the moment).
